### PR TITLE
Fix .gen being too large on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -169,4 +169,8 @@ a:visited {
         flex-direction: column;
         align-items: center;
     }
+
+    .gen {
+        min-width: initial;
+    }
 }


### PR DESCRIPTION
The previous behaviour had the sections extend too far for mobile displays due to the 400px min-width style. This fixes the issue by negating the min-width declaration in a media query.